### PR TITLE
Fix the copy link URL showing when permalink is set as plain

### DIFF
--- a/copy-link-to-heading.php
+++ b/copy-link-to-heading.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Copy Link to Heading
  * Description: Adds a copy link icon to headings for easy copying, bookmarking, sharing, and navigation within the content.
- * Version: 1.4
+ * Version: 1.5
  * Author: Jose Varghese
  * Requires at least: 5.0
  * Requires PHP: 7.0

--- a/js/clth-script.js
+++ b/js/clth-script.js
@@ -19,8 +19,9 @@ document.addEventListener('DOMContentLoaded', function () {
     function sanitizeSlug(text) {
         return text
             .toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-')  // Replace non-alphanumeric characters with hyphen
-            .replace(/^-+|-+$/g, '');
+            .replace(/[^a-z0-9 ]+/g, '')  // Remove special characters but keep spaces
+            .trim()
+            .replace(/\s+/g, '-');       // Replace spaces with hyphens
     }
 
     contentElements.forEach(function (content) {
@@ -41,7 +42,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         // Create tooltip element
                         const tooltip = document.createElement('span');
                         tooltip.classList.add('clth-tooltip');
-                        tooltip.textContent = copyText;
+                        tooltip.textContent = copyText; // Keep spaces intact
 
                         // Append tooltip to the icon
                         icon.appendChild(tooltip);
@@ -55,7 +56,7 @@ document.addEventListener('DOMContentLoaded', function () {
                             if (enableTooltip) {
                                 // Change tooltip text to "Copied"
                                 const tooltip = icon.querySelector('.clth-tooltip');
-                                tooltip.textContent = copiedText;
+                                tooltip.textContent = copiedText; // Keep spaces intact
 
                                 // Revert back to the original text after 2 seconds
                                 setTimeout(() => {

--- a/js/clth-script.js
+++ b/js/clth-script.js
@@ -51,7 +51,9 @@ document.addEventListener('DOMContentLoaded', function () {
                     heading.appendChild(icon);
 
                     icon.addEventListener('click', function () {
-                        const url = `${window.location.origin}${window.location.pathname}#${heading.id}`;
+                        const baseUrl = window.location.href.split('#')[0]; // Preserve full URL
+                        const url = `${baseUrl}#${heading.id}`; // Append the heading ID
+
                         navigator.clipboard.writeText(url).then(() => {
                             if (enableTooltip) {
                                 // Change tooltip text to "Copied"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: headings, copy link, content navigation, deep linking, anchor links
 Requires at least: 5.0
 Tested up to: 6.7.2
 Requires PHP: 7.0
-Stable tag: 1.4
+Stable tag: 1.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Eventhough its not recommended to set the permalink as plain, this PR will fix the anchor link to generate with the heading text